### PR TITLE
add kdrag0n's "stop statsd collection service" commit to apex module

### DIFF
--- a/apex/statsd.rc
+++ b/apex/statsd.rc
@@ -18,3 +18,4 @@ service statsd /apex/com.android.os.statsd/bin/statsd
     user statsd
     group statsd log
     task_profiles ServiceCapacityLow
+    disabled


### PR DESCRIPTION
So, this branch should first get `git reset --hard` to `lineage-20.0` branch of [https://github.com/LineageOS/android_packages_modules_StatsD](https://github.com/LineageOS/android_packages_modules_StatsD), then have [https://github.com/Terminator-J/crdroid_packages_modules_StatsD/commit/4c6c2d4685a7cf287a68d5a73d59076b1d2ecb81](https://github.com/Terminator-J/crdroid_packages_modules_StatsD/commit/4c6c2d4685a7cf287a68d5a73d59076b1d2ecb81) applied to it.

Not 177 commits.

But since I can't directly manage the crdroidandroid org repo, this was the easiest way to make the request. 😁 

Hopefully this solves the vicious CPU usage after ~85 hours of uptime that some of my users on Android 13 have been experiencing for over a year.